### PR TITLE
Use args which includes button when necessary

### DIFF
--- a/src/Reflex/Dom/DHTMLX/Common.hs
+++ b/src/Reflex/Dom/DHTMLX/Common.hs
@@ -36,6 +36,6 @@ js_createDhtmlxCalendar btnElmt elmt wstart = do
     (args <# "input") elmt
     mapM_ (args <# "button") btnElmt
     calendarObj <- js_dhtmlXCalendarObject
-    cal <- new calendarObj $ pToJSVal elmt
+    cal <- new calendarObj $ toJSVal args
     void $ cal ^. js1 "setWeekStartDay" (weekDayToInt wstart)
     return cal


### PR DESCRIPTION
`calendarObj` was not being passed the object that included the `input` field. This fixes opening the calendar via the button element if it exists.