### PR TITLE
Datetime widget uses setFormatedDate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+result

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reflex-platform"]
+	path = reflex-platform
+	url = https://github.com/reflex-frp/reflex-platform

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+(import ./reflex-platform {}).project ({ pkgs, ... }: {
+  useWarp = true;
+  packages = {
+    dhtmlx = ../reflex-dhtmlx;
+  };
+
+  shells = {
+    ghc = ["dhtmlx"];
+    ghcjs = ["dhtmlx"];
+  };
+})

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,21 +1,27 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
 {-# LANGUAGE RecursiveDo       #-}
 
 module Main (main) where
 
-import qualified Data.Text               as T
-import Reflex.Dom
-import Reflex.Dom.DHTMLX.DateTime
+import qualified Data.Text                        as T
+import           Language.Javascript.JSaddle.Types (JSM)
+import           Reflex.Dom
+import           Reflex.Dom.DHTMLX.DateTime
+
+
+app :: MonadWidget t m => m ()
+app = do
+  el "h1" $ text "Date Widget Test"
+  rec date <- dhtmlxDateTimePicker $ def
+                & dateTimePickerConfig_button .~ (Just $ _element_raw e)
+      (e,_) <- el' "span" $ text "cal"
+  el "div" $
+    dynText $ maybe "Nothing" (T.pack . show) <$> value date
+  return ()
+
 
 main :: IO ()
-main = mainWidget $ do
-    el "h1" $ text "Date Widget Test"
-    rec date <- dhtmlxDateTimePicker $ def
-                  & dateTimePickerConfig_button .~ (Just $ _element_raw e)
-        (e,_) <- el' "span" $ text "cal"
-    el "div" $
-      dynText $ maybe "Nothing" (T.pack . show) <$> value date
-    return ()
+main = mainWidget app

--- a/reflex-dhtmlx.cabal
+++ b/reflex-dhtmlx.cabal
@@ -1,7 +1,7 @@
 name:                reflex-dhtmlx
 version:             0.1
 synopsis:            Reflex wrapper for DHTMLX widgets
--- description:         
+-- description:
 license:             BSD3
 license-file:        LICENSE
 author:              Doug Beardsley
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  include-dirs: include
+  include-dirs:        include
   js-sources:
     -- Order is important (the reverse of what you think)
     -- removing this so we can lazy load the js source to have
@@ -23,10 +23,10 @@ library
   exposed-modules:
     Reflex.Dom.DHTMLX.Date
     Reflex.Dom.DHTMLX.DateTime
-  
+
   other-modules:
     Reflex.Dom.DHTMLX.Common
-  
+
   build-depends:
       base         >= 4.9  && < 4.10
     , containers   >= 0.5  && < 0.6
@@ -39,27 +39,21 @@ library
     , reflex-dom   >= 0.4  && < 0.5
     , text         >= 1.2  && < 1.3
     , time         >= 1.6  && < 1.8
-  
+
   ghc-options: -Wall -fno-warn-unused-do-bind
 
   default-language:    Haskell2010
-  
-Flag Example
-  description: Enable example
-  default: False
 
-test-suite example
-  if flag(Example)
-    buildable: True
-  else
-    buildable: False
-  type:              exitcode-stdio-1.0
+executable example
+  buildable: True
   main-is:           Main.hs
   hs-source-dirs:    example
   default-language:  Haskell2010
 
   build-depends:
       base
+    , jsaddle
+    , jsaddle-warp
     , reflex
     , reflex-dom
     , reflex-dhtmlx

--- a/src/Reflex/Dom/DHTMLX/Common.hs
+++ b/src/Reflex/Dom/DHTMLX/Common.hs
@@ -4,6 +4,7 @@
 module Reflex.Dom.DHTMLX.Common where
 
 import Control.Monad
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Lens
 import Data.Default
 import Data.Text (Text)
@@ -47,6 +48,9 @@ setDateFormat cal fmt = liftJSM $ void $ cal ^. js1 "setDateFormat" fmt
 setDate :: MonadJSM m => DhtmlxCalendar -> Text -> m ()
 setDate cal date = liftJSM $ void $ cal ^. js1 "setDate" date
 
+setFormattedDate :: MonadJSM m => DhtmlxCalendar -> Text -> Text -> m ()
+setFormattedDate cal fmt date = liftJSM $ void $ cal ^. js2 "setFormatedDate" fmt date
+
 showTime :: MonadJSM m => DhtmlxCalendar -> m ()
 showTime cal = liftJSM $ void $ cal ^. js0 "showTime"
 
@@ -73,6 +77,7 @@ createDhtmlxCalendar
   :: CalendarConfig
   -> JSM DhtmlxCalendar
 createDhtmlxCalendar config = do
+    liftIO $ putStrLn "new calendar"
     let createCal v = DhtmlxCalendar <$> new js_dhtmlXCalendarObject v
     cal <- case _calendarConfig_parent config of
       Nothing -> do
@@ -117,4 +122,3 @@ instance Default CalendarConfig where
   def = CalendarConfig Nothing Nothing Nothing Monday Minutes1
 
 makeLenses ''CalendarConfig
-

--- a/src/Reflex/Dom/DHTMLX/Common.hs
+++ b/src/Reflex/Dom/DHTMLX/Common.hs
@@ -4,7 +4,6 @@
 module Reflex.Dom.DHTMLX.Common where
 
 import Control.Monad
-import Control.Monad.IO.Class (MonadIO(..))
 import Control.Lens
 import Data.Default
 import Data.Text (Text)
@@ -77,7 +76,6 @@ createDhtmlxCalendar
   :: CalendarConfig
   -> JSM DhtmlxCalendar
 createDhtmlxCalendar config = do
-    liftIO $ putStrLn "new calendar"
     let createCal v = DhtmlxCalendar <$> new js_dhtmlXCalendarObject v
     cal <- case _calendarConfig_parent config of
       Nothing -> do

--- a/src/Reflex/Dom/DHTMLX/Date.hs
+++ b/src/Reflex/Dom/DHTMLX/Date.hs
@@ -131,4 +131,3 @@ dhtmlxDatePicker (DatePickerConfig iv sv b p wstart attrs visibleOnLoad) = do
       return ups
     let parser = parseTimeM True defaultTimeLocale fmt . T.unpack
     fmap DatePicker $ holdDyn iv $ parser <$> leftmost [_textInput_input ti, ups]
-

--- a/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -52,6 +52,20 @@ createDhtmlxDateTimeWidgetButton
     -> JSM DateTimeWidgetRef
 createDhtmlxDateTimeWidgetButton btnElmt = createDhtmlxDateTimeWidget' (Just btnElmt)
 
+
+dateTimeFormat :: String
+dateTimeFormat = "%Y-%m-%d %H:%M"
+-- "%Y-%m-%d %H:%M"
+
+
+calendarsDateTimeFormat :: String
+calendarsDateTimeFormat = "%Y-%m-%d %H:%i"
+
+
+dateTimeFormatter :: UTCTime -> String
+dateTimeFormatter = formatTime defaultTimeLocale dateTimeFormat
+
+
 ------------------------------------------------------------------------------
 createDhtmlxDateTimeWidget'
     :: Maybe Element
@@ -66,13 +80,14 @@ createDhtmlxDateTimeWidget' btnElmt elmt wstart mint = do
           & calendarConfig_weekStart .~ wstart
     cal <- createDhtmlxCalendar config
     setMinutesInterval cal mint
-    setDateFormat cal $ T.pack "%Y-%m-%d %H:%i"
+    setDateFormat cal $ T.pack calendarsDateTimeFormat
     showTime cal
     return $ DateTimeWidgetRef cal
 
 ------------------------------------------------------------------------------
 getDateTimeWidgetValue :: MonadJSM m => DateTimeWidgetRef -> m Text
-getDateTimeWidgetValue a = liftJSM $ valToText =<< a ^. js1 "getFormatedDate" "%Y-%m-%d %H:%i"
+getDateTimeWidgetValue a
+  = liftJSM $ valToText =<< a ^. js1 "getFormatedDate" calendarsDateTimeFormat
 
 
 ------------------------------------------------------------------------------
@@ -80,8 +95,15 @@ dateWidgetUpdates
     :: (TriggerEvent t m, MonadJSM m) => DateTimeWidgetRef -> m (Event t Text)
 dateWidgetUpdates cal = do
     (event, trigger) <- newTriggerEvent
-    void $ liftJSM $ cal ^. js2 "attachEvent" "onClick" (fun $ \_ _ _ -> liftIO . trigger =<< getDateTimeWidgetValue cal)
-    void $ liftJSM $ cal ^. js2 "attachEvent" "onTimeChange" (fun $ \_ _ _ -> liftIO . trigger =<< getDateTimeWidgetValue cal)
+    let onClickCB = fun $ \_ _ _ -> do
+          txt <- getDateTimeWidgetValue cal
+          liftIO $ trigger txt
+    void $ liftJSM $ cal ^. js2 "attachEvent" "onClick" onClickCB
+
+    let onTimeChangeCB = fun $ \_ _ _ -> do
+          txt <- getDateTimeWidgetValue cal
+          liftIO $ trigger txt
+    void $ liftJSM $ cal ^. js2 "attachEvent" "onTimeChange" onTimeChangeCB
     return event
 
 ------------------------------------------------------------------------------
@@ -119,12 +141,13 @@ dhtmlxDateTimePicker
     => DateTimePickerConfig t
     -> m (DateTimePicker t)
 dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOnLoad) = mdo
-    let fmt = "%Y-%m-%d %H:%M"
-        formatter = T.pack . maybe "" (formatTime defaultTimeLocale fmt)
+    let formatter = T.pack . maybe "" dateTimeFormatter
+        ivTxt     = formatter iv
+        evVal     = leftmost [formatter <$> sv, ups]
     ti <- textInput $ def
       & attributes .~ attrs
-      & textInputConfig_initialValue .~ formatter iv
-      & textInputConfig_setValue .~ leftmost [fmap formatter sv, ups]
+      & textInputConfig_initialValue .~ ivTxt
+      & textInputConfig_setValue .~ evVal
     let dateEl = toElement $ _textInput_element ti
         config = def
             & calendarConfig_button .~ b
@@ -137,6 +160,16 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
       when (isJust p) $ setPosition cal 0 0
       ups' <- dateWidgetUpdates $ DateTimeWidgetRef cal
       performEvent_ $ dateWidgetHide cal <$ ups'
+      performEvent_ $ ffor (fmapMaybe (fmap (T.pack . dateTimeFormatter)) sv) $
+        setFormattedDate cal $ T.pack calendarsDateTimeFormat
       return ups'
-    let parser = parseTimeM True defaultTimeLocale fmt . T.unpack
-    fmap DateTimePicker $ holdDyn iv $ parser <$> leftmost [_textInput_input ti, ups]
+    let parser   = parseTimeM True defaultTimeLocale dateTimeFormat . T.unpack
+        evParsed = parser <$> leftmost [_textInput_input ti, ups]
+    performEvent_ $ liftIO . putStrLn . ("sv  : " ++) . show <$> sv
+    performEvent_ $ liftIO . putStrLn . ("fsv : " ++) . show . formatter <$> sv
+    performEvent_ $ liftIO . putStrLn . ("ups : " ++) . show <$> ups
+    performEvent_ $ liftIO . putStrLn . ("pups: " ++) . show . parser <$> ups
+    performEvent_ $ liftIO . putStrLn . ("ti  : " ++) . show <$> _textInput_input ti
+    performEvent_ $ liftIO . putStrLn . ("=   : " ++) . show <$> evParsed
+    dVal    <- holdDyn iv evParsed
+    return $ DateTimePicker dVal

--- a/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -55,7 +55,6 @@ createDhtmlxDateTimeWidgetButton btnElmt = createDhtmlxDateTimeWidget' (Just btn
 
 dateTimeFormat :: String
 dateTimeFormat = "%Y-%m-%d %H:%M"
--- "%Y-%m-%d %H:%M"
 
 
 calendarsDateTimeFormat :: String
@@ -165,11 +164,5 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
       return ups'
     let parser   = parseTimeM True defaultTimeLocale dateTimeFormat . T.unpack
         evParsed = parser <$> leftmost [_textInput_input ti, ups]
-    performEvent_ $ liftIO . putStrLn . ("sv  : " ++) . show <$> sv
-    performEvent_ $ liftIO . putStrLn . ("fsv : " ++) . show . formatter <$> sv
-    performEvent_ $ liftIO . putStrLn . ("ups : " ++) . show <$> ups
-    performEvent_ $ liftIO . putStrLn . ("pups: " ++) . show . parser <$> ups
-    performEvent_ $ liftIO . putStrLn . ("ti  : " ++) . show <$> _textInput_input ti
-    performEvent_ $ liftIO . putStrLn . ("=   : " ++) . show <$> evParsed
-    dVal    <- holdDyn iv evParsed
+    dVal <- holdDyn iv evParsed
     return $ DateTimePicker dVal


### PR DESCRIPTION
* Allows the datetime widget to set the time portion of the clock
* Makes the difference between UTCTime format strings and the dthmlxcalendar's format strings a bit more explicit
* Adds the ability to build the project in some stand alone capacity with `reflex-platform`