### PR TITLE
Time input race condition fix

### DIFF
--- a/reflex-dhtmlx-example/src/Main.hs
+++ b/reflex-dhtmlx-example/src/Main.hs
@@ -8,6 +8,8 @@ module Main (main) where
 
 import           Control.Monad.IO.Class     (liftIO)
 import qualified Data.Text                  as T
+import           Data.Time.Clock            (addUTCTime, getCurrentTime,
+                                             utctDay)
 import           Data.Time.LocalTime
 import           Reflex.Dom
 import           Reflex.Dom.DHTMLX.Date
@@ -18,21 +20,46 @@ app :: MonadWidget t m => m ()
 app = do
   zone <- liftIO getCurrentTimeZone
 
+  yesterday <- addUTCTime (realToFrac . negate $ 60 * 60 * 24) <$> liftIO getCurrentTime
+
   el "section" $ do
     el "h2" $ text "Date Time Widget Test"
+    text "we set this widget to be 24 hours ago by default"
     rec date <- dhtmlxDateTimePicker $ def
                   & dateTimePickerConfig_button .~ Just (_element_raw e)
                   & dateTimePickerConfig_timeZone .~ zone
+                  & dateTimePickerConfig_initialValue .~ Just yesterday
         (e,_) <- el' "button" $ text "cal"
     el "div" . dynText $ T.pack . ("selected time is: " ++) . show <$> value date
     el "span" . text . T.pack $ "your time zone is: " ++ show zone
+    return date
+
+    el "h2" $ text "Date Time Widget based on the above widget"
+    text "we leave this one unset to show default behavior"
+    rec date' <- dhtmlxDateTimePicker $ def
+                  & dateTimePickerConfig_button .~ Just (_element_raw e)
+                  & dateTimePickerConfig_timeZone .~ zone
+                  & dateTimePickerConfig_setValue .~ updated (_dateTimePicker_value date)
+        (e,_) <- el' "button" $ text "cal"
+    el "div" . dynText $ T.pack . ("selected time is: " ++) . show <$> value date'
+
 
   el "section" $ do
     el "h2" $ text "Date Widget Test"
+    text "we set this widget to be 24 hours ago by default"
     rec date <- dhtmlxDatePicker $ def
                   & datePickerConfig_button .~ Just (_element_raw e)
+                  & datePickerConfig_initialValue .~ Just (utctDay yesterday)
         (e,_) <- el' "button" $ text "cal"
     el "div" . dynText $ T.pack . ("selected time is: " ++) . show <$> value date
+
+    el "h2" $ text "Date Widget Test based on the above widget"
+    text "we leave this one unset to show default behavior"
+    rec date' <- dhtmlxDatePicker $ def
+                  & datePickerConfig_button .~ Just (_element_raw e)
+                  & datePickerConfig_setValue .~ updated (_datePicker_value date)
+        (e,_) <- el' "button" $ text "cal"
+    el "div" . dynText $ T.pack . ("selected time is: " ++) . show <$> value date'
 
 
 {-|

--- a/reflex-dhtmlx-example/src/Main.hs
+++ b/reflex-dhtmlx-example/src/Main.hs
@@ -24,7 +24,7 @@ app = do
 
   el "section" $ do
     el "h2" $ text "Date Time Widget Test"
-    text "we set this widget to be 24 hours ago by default"
+    el "div" $ text "we set this widget to be 24 hours ago by default"
     rec date <- dhtmlxDateTimePicker $ def
                   & dateTimePickerConfig_button .~ Just (_element_raw e)
                   & dateTimePickerConfig_timeZone .~ zone
@@ -35,7 +35,7 @@ app = do
     return date
 
     el "h2" $ text "Date Time Widget based on the above widget"
-    text "we leave this one unset to show default behavior"
+    el "div" $ text "we leave this one unset to show default behavior"
     rec date' <- dhtmlxDateTimePicker $ def
                   & dateTimePickerConfig_button .~ Just (_element_raw e)
                   & dateTimePickerConfig_timeZone .~ zone
@@ -46,7 +46,7 @@ app = do
 
   el "section" $ do
     el "h2" $ text "Date Widget Test"
-    text "we set this widget to be 24 hours ago by default"
+    el "div" $ text "we set this widget to be 24 hours ago by default"
     rec date <- dhtmlxDatePicker $ def
                   & datePickerConfig_button .~ Just (_element_raw e)
                   & datePickerConfig_initialValue .~ Just (utctDay yesterday)
@@ -54,7 +54,7 @@ app = do
     el "div" . dynText $ T.pack . ("selected time is: " ++) . show <$> value date
 
     el "h2" $ text "Date Widget Test based on the above widget"
-    text "we leave this one unset to show default behavior"
+    el "div" $ text "we leave this one unset to show default behavior"
     rec date' <- dhtmlxDatePicker $ def
                   & datePickerConfig_button .~ Just (_element_raw e)
                   & datePickerConfig_setValue .~ updated (_datePicker_value date)

--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/Common.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/Common.hs
@@ -15,7 +15,6 @@ module Reflex.Dom.DHTMLX.Common
   , setPosition
   , withCalendar
   , showTime, hideTime
-  , setDate
   , setFormattedDate, setDateFormat
   , minutesIntervalToInt
   ) where
@@ -60,9 +59,6 @@ setPosition cal x y = liftJSM $ void $ cal ^. js2 "setPosition" x y
 
 setDateFormat :: MonadJSM m => DhtmlxCalendar -> Text -> m ()
 setDateFormat cal fmt = liftJSM $ void $ cal ^. js1 "setDateFormat" fmt
-
-setDate :: MonadJSM m => DhtmlxCalendar -> Text -> m ()
-setDate cal date = liftJSM $ void $ cal ^. js1 "setDate" date
 
 setFormattedDate :: MonadJSM m => DhtmlxCalendar -> Text -> Text -> m ()
 setFormattedDate cal fmt date = liftJSM $ void $ cal ^. js2 "setFormatedDate" fmt date

--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -11,6 +11,8 @@
 module Reflex.Dom.DHTMLX.DateTime
   ( dhtmlxDateTimePicker
   , DateTimePickerConfig (..)
+  , DateTimePicker
+  , _dateTimePicker_value
   , dateTimePickerConfig_initialValue
   , dateTimePickerConfig_setValue
   , dateTimePickerConfig_button
@@ -130,10 +132,11 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
     let formatter = T.pack . maybe ""
           (formatTime defaultTimeLocale dateTimeFormat . utcToZonedTime zone)
         ivTxt     = formatter iv
+    pb <- getPostBuild
     ti <- textInput $ def
       & attributes .~ attrs
       & textInputConfig_initialValue .~ ivTxt
-      & textInputConfig_setValue .~ leftmost [formatter <$> sv, formatter . parser <$> ups]
+      & textInputConfig_setValue .~ leftmost [formatter <$> sv, formatter . parser <$> ups, ivTxt <$ pb]
     let dateEl = toElement $ _textInput_element ti
         config = def
             & calendarConfig_button .~ b
@@ -153,6 +156,7 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
       return ups'
     let parser   = fmap (zonedTimeToUTC . (\dd -> dd {zonedTimeZone = zone}))
                  . parseTimeM True defaultTimeLocale dateTimeFormat . T.unpack
-        evParsed = parser <$> leftmost [_textInput_input ti, ups]
+        evParsed = leftmost [parser <$> leftmost [_textInput_input ti, ups], sv]
     dVal <- holdDyn iv evParsed
     return $ DateTimePicker dVal
+

--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -132,10 +132,10 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
     let formatter = T.pack . maybe ""
           (formatTime defaultTimeLocale dateTimeFormat . utcToZonedTime zone)
         ivTxt     = formatter iv
+    -- we set the text input with postBuild due to a race condition in dhtmlx-calendar
     pb <- getPostBuild
     ti <- textInput $ def
       & attributes .~ attrs
-      & textInputConfig_initialValue .~ ivTxt
       & textInputConfig_setValue .~ leftmost [formatter <$> sv, formatter . parser <$> ups, ivTxt <$ pb]
     let dateEl = toElement $ _textInput_element ti
         config = def
@@ -156,7 +156,7 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
       return ups'
     let parser   = fmap (zonedTimeToUTC . (\dd -> dd {zonedTimeZone = zone}))
                  . parseTimeM True defaultTimeLocale dateTimeFormat . T.unpack
-        evParsed = leftmost [parser <$> leftmost [_textInput_input ti, ups], sv]
+        evParsed = leftmost [parser <$> _textInput_input ti, parser <$> ups, sv]
     dVal <- holdDyn iv evParsed
     return $ DateTimePicker dVal
 


### PR DESCRIPTION
fixing time input bug by addressing dateFormat setting race condition, where data is parsed before the format is set