### PR TITLE
Remove reflex-side hide logic.

### DIFF
--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/Date.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/Date.hs
@@ -119,7 +119,6 @@ dhtmlxDatePicker (DatePickerConfig iv sv b p wstart attrs visibleOnLoad) = do
       when (isJust p) $ setPosition cal 0 0
       when visibleOnLoad $ dateWidgetShow cal
       ups <- dateWidgetUpdates $ DateWidgetRef cal
-      performEvent_ $ dateWidgetHide cal <$ ups
       return ups
     let parser = parseTimeM True defaultTimeLocale fmt . T.unpack
     fmap DatePicker $ holdDyn iv $ leftmost [parser <$> _textInput_input ti, parser <$> ups, sv]

--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -150,7 +150,6 @@ dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOn
       setMinutesInterval cal mint
       setDateFormat cal $ T.pack calendarsDateTimeFormat
       ups' <- dateWidgetUpdates $ DateTimeWidgetRef cal
-      performEvent_ $ dateWidgetHide cal <$ ups'
       performEvent_ $ ffor (fmapMaybe (fmap (T.pack . dateTimeFormatter)) sv) $
          setFormattedDate cal $ T.pack dateTimeFormat
       return ups'


### PR DESCRIPTION
For dhtmlDatePicker picker, the reflex-side hide logic was redundant
with the hardcoded dhtmlx calendar behavior when bound to an input
element. For dhtmlDateTimePicker, it caused a close when the time is
set, which is a variation from dhtmlx norms and is undesirable for our
use cases.