### PR TITLE
Fix reflex-dhtmlx race condition

### DIFF
--- a/reflex-dhtmlx-example/reflex-dhtmlx-example.cabal
+++ b/reflex-dhtmlx-example/reflex-dhtmlx-example.cabal
@@ -28,6 +28,7 @@ executable example
     , time
     , text          >= 1.2  && < 1.3
     , transformers
+    , tz
 
 source-repository head
   type: git

--- a/reflex-dhtmlx-example/src/Main.hs
+++ b/reflex-dhtmlx-example/src/Main.hs
@@ -11,6 +11,8 @@ import qualified Data.Text                  as T
 import           Data.Time.Clock            (addUTCTime, getCurrentTime,
                                              utctDay)
 import           Data.Time.LocalTime
+import           Data.Time.Zones
+import           Data.Time.Zones.Types
 import           Reflex.Dom
 import           Reflex.Dom.DHTMLX.Date
 import           Reflex.Dom.DHTMLX.DateTime
@@ -18,7 +20,7 @@ import           Reflex.Dom.DHTMLX.DateTime
 
 app :: MonadWidget t m => m ()
 app = do
-  zone <- liftIO getCurrentTimeZone
+  let zone = tzByLabel America__Los_Angeles
 
   yesterday <- addUTCTime (realToFrac . negate $ 60 * 60 * 24) <$> liftIO getCurrentTime
 

--- a/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
+++ b/reflex-dhtmlx/src/Reflex/Dom/DHTMLX/DateTime.hs
@@ -136,7 +136,8 @@ dhtmlxDateTimePicker
 dhtmlxDateTimePicker (DateTimePickerConfig iv sv b p wstart mint attrs visibleOnLoad zone hideRule) = mdo
     let formatter = T.pack . maybe "" (formatTime defaultTimeLocale dateTimeFormat . utcToZonedTime' zone)
     -- we set the text input with postBuild due to a race condition in dhtmlx-calendar
-    pb <- getPostBuild
+    -- add 100ms to avoid it more
+    pb <- delay 0.1 =<< getPostBuild
     ti <- textInput $ def
       & attributes .~ attrs
       & textInputConfig_setValue .~ leftmost [formatter <$> sv, formatter . parser <$> ups, formatter iv <$ pb]


### PR DESCRIPTION
We've been hitting this race condition in a large app. The hours and minutes get overwritten by the DHTMLX time date widget. Adding a 100ms delay seems to avoid it.